### PR TITLE
feat (DP-10): 데이터 필터링 및 S3 적재 코드 및 테스트 완료

### DIFF
--- a/filter_data_and_upload_to_s3.py
+++ b/filter_data_and_upload_to_s3.py
@@ -180,10 +180,6 @@ region_dict_default = get_weekly_region(weekly_default_dict)
 gps_dict_default = get_weekly_gps(weekly_default_dict)
 
 
-
-
-
-
 # S3 클라이언트 생성
 s3_client = boto3.client('s3')
 
@@ -211,7 +207,7 @@ def upload_to_s3(data, is_gps, current_path=""):
             base_path = f"{transformed_key}/region_data"
             file_name = f"{base_path.split('/')[-1]}_{transformed_key}"
 
-        s3_key = f"{s3_folder}/py_test/{base_path}/{file_name}.parquet"
+        s3_key = f"{s3_folder}/{base_path}/{file_name}.parquet"
 
         if isinstance(value, pd.DataFrame):  # 값이 DataFrame인 경우
             # DataFrame을 Parquet로 변환
@@ -220,15 +216,15 @@ def upload_to_s3(data, is_gps, current_path=""):
 
             # S3 업로드
             try:
-                print(f"Uploading DataFrame to {s3_key}...")
+                print(f"--------------------- S3에 DataFrame 적재중 {s3_key} ---------------------")
                 s3_client.put_object(
                     Bucket=bucket_name,
                     Key=s3_key,
                     Body=parquet_buffer.getvalue()
                 )
-                print(f"Successfully uploaded: {s3_key}\n")
+                print(f"--------------------- S3에 DataFrame 적재 완료! {s3_key} ---------------------\n")
             except Exception as e:
-                print(f"Error uploading {s3_key}: {e}\n")
+                print(f"--------------------- S3에 적재 중 에러 발생 {s3_key}: {e} ---------------------\n")
 
         elif isinstance(value, dict):  # 값이 딕셔너리인 경우 (이중 딕셔너리 처리)
             for sub_key, sub_value in value.items():
@@ -240,7 +236,7 @@ def upload_to_s3(data, is_gps, current_path=""):
                     sub_file_path = f"{transformed_key}/region_data"
                     sub_file_name = f"{sub_key}_{transformed_key}"
 
-                sub_s3_key = f"{s3_folder}/py_test/{sub_file_path}/{sub_file_name}.parquet"
+                sub_s3_key = f"{s3_folder}/{sub_file_path}/{sub_file_name}.parquet"
 
                 if isinstance(sub_value, pd.DataFrame):  # 이중 딕셔너리의 값이 DataFrame인 경우
                     # DataFrame을 Parquet로 변환
@@ -249,19 +245,23 @@ def upload_to_s3(data, is_gps, current_path=""):
 
                     # S3 업로드
                     try:
-                        print(f"Uploading DataFrame to {sub_s3_key}...")
+                        print(f"--------------------- S3에 DataFrame 적재중 {sub_s3_key} ---------------------")
                         s3_client.put_object(
                             Bucket=bucket_name,
                             Key=sub_s3_key,
                             Body=parquet_buffer.getvalue()
                         )
-                        print(f"Successfully uploaded: {sub_s3_key}\n")
+                        print(f"--------------------- S3에 DataFrame 적재 완료! {sub_s3_key} ---------------------\n")
                     except Exception as e:
-                        print(f"Error uploading {sub_s3_key}: {e}\n")
+                        print(f"--------------------- S3에 적재 중 에러 발생 {sub_s3_key}: {e} ---------------------\n")
                 else:
-                    print(f"Unsupported data type in nested dictionary: {type(sub_value)}\n")
+                    print(f"--------------------- Data가 Nested Dictionary가 아닙니다: {type(sub_value)} ---------------------\n")
         else:
-            print(f"Unsupported data type: {type(value)}\n")
+            print(f"--------------------- 지원하지 않는 Data Type {type(value)} ---------------------\n")
+    print(f"===================== S3에 모든 데이터 적제 완료! {s3_folder} =====================\n")
 
+# region 데이터 S3 적재
 upload_to_s3(region_dict_default, is_gps=False)
+
+# region 데이터 S3 적재
 upload_to_s3(gps_dict_default, is_gps=True)


### PR DESCRIPTION
### `filter_data_and_upload_to_s3.py` 파일을 수정 후 테스트까지 완료했습니다.
- 해당 파일은 로컬에 저장된 gps, region parquet 파일을 1주 단위로 필터링한 후, 그대로 S3에 폴더를 생성하여 업로드합니다.
    - 기존 `upload_to_s3.py` 파일은 `one_week_data_for_test.ipynb` 를 통해 필터링 후 로컬에 저장된 파일을 불러오는 구조였습니다.
    - `filter_data_and_upload_to_s3.py`는 `one_week_data_for_test.ipynb`와 `upload_to_s3.py` 파일을 합친 코드입니다.
        - 이 코드는, 두 작업 사이 로컬에 필터링한 파일을 저장하는 과정을 생략합니다.
- 이전에 작성된 `upload_to_s3` 함수 코드에는 `py_test`라는 경로가 있었으나, 해당 경로는 제거했습니다.
- 해당 파일 실행 시, [S3](https://ap-northeast-2.console.aws.amazon.com/s3/buckets/travel-de-storage?region=ap-northeast-2&bucketType=general&prefix=raw-data/&showversions=false)에 적재되는 경로는 아래와 같습니다.
```
📦 travel-de-storage
└─ raw-data
   ├─ 220102
   │  ├─ gps_data
   │  │  └─ gps_data_220102.parquet
   │  └─ region_data
   │     └─ tn_activity_consume_his_활동소비내역_220102.parquet
   └─ 220109
      ├─ gps_data
      │  └─ gps_data_220109.parquet
      └─ region_data
         └─ tn_activity_consume_his_활동소비내역_220109.parquet
```