### PR TITLE
feat (DP-20): Docker Compose 설정 Revert

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -123,13 +123,9 @@ services:
 
   airflow-webserver:
     <<: *airflow-common
-    image: custom-airflow:latest
     command: webserver
     ports:
       - "8080:8080"
-    volumes:
-      - airflow-logs:/opt/airflow/logs
-      - airflow-dags:/opt/airflow/dags
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
       interval: 30s
@@ -141,7 +137,6 @@ services:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
-
 
   airflow-scheduler:
     <<: *airflow-common
@@ -313,9 +308,4 @@ services:
     restart: no
 
 volumes:
-  airflow-logs:
-    driver: local
-  airflow-dags:
-    driver: local
   postgres-db-volume:
-    driver: local


### PR DESCRIPTION
### 기존 Docker Compose 설정을 수정하여 Airflow 환경 Revert
- Dockerfile 만 유지하고, docker-compose.yaml 파일은 기존의 상태로 돌려놓음.

주요 변경사항
- Volumes 제거
- x-airflow-common: 에서 'build' 대신 'image'로 apache-airflow:2.9.1 이 들어가 있음.
